### PR TITLE
Fixed registration link on french page.

### DIFF
--- a/FR/index.html
+++ b/FR/index.html
@@ -174,7 +174,7 @@
         <div class="container">
             <div class="row text-center">
                  <div class="col-xl-8 col-xl-offset-2 col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-xs-12 col-xs-offset-0">
-					<p><h3><a href="http://www.rbiq-qbin.qc.ca/en/event/5051" target="_blank">Les inscriptions pour le hackathon de Montreal sont maintenant ouvertes!</a></h3></p>
+					<p><h3><a href="http://www.rbiq-qbin.qc.ca/en/event/5051?locale=fr" target="_blank">Les inscriptions pour le hackathon de Montreal sont maintenant ouvertes!</a></h3></p>
 		    <p>Brainhack Montreal 2017 fait parti de <a href="http://events.brainhack.org/global2017/" target="_blank">Global Brainhack 2017</a>, qui regroupe plus de 40 hackathons simultanés dans le monde. L'objectif de brainhack est de réunir des chercheurs d'horizons divers pour collaborer ensemble et de maniére transparente sur des projets de neuroimagerie.</p>
 					<h4>Dates: 2-3 mars 2017</h4>
 					<h4>Prix: $20 CAD, incluant petit déjeuner et diner.</h4>


### PR DESCRIPTION
I'm not sure if the QBIN website is deciding what language to show based on the user's locale, but on my computer the french registration link was going to the english registration page.